### PR TITLE
Update "Set up JDBC Driver" section

### DIFF
--- a/topics/setting-up-teamcity-with-ms-sql-server.md
+++ b/topics/setting-up-teamcity-with-ms-sql-server.md
@@ -52,13 +52,13 @@ SQL Server supports two ways of authentication: SQL Server authentication and Wi
 
 ### Set up JDBC Driver for SQL Server database
 
-1. Download the [Microsoft JDBC driver v6.0+](https://www.microsoft.com/en-us/download/details.aspx?id=55539) (the `sqljdbc_6.0.x` package, `.exe` or `.tar.gz` depending on your TeamCity server platform) from the Microsoft Download Center.   
+1. Download a [Microsoft JDBC driver version 6.0 or higher](https://docs.microsoft.com/en-us/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server) (pick `.exe` or `.tar.gz` depending on your TeamCity server platform) from the Microsoft Download Center.   
 2. Unpack the downloaded package into a temporary directory.   
-3. Copy the `sqljdbc42.jar` package from the just downloaded package into the `<`[`TeamCity Data Directory`](teamcity-data-directory.md)`>/lib/jdbc` directory.
+3. Copy the `sqljdbc42.jar` (or `mssql-jdbc-<version>.jre8.jar` in versions above 6.0) package from the just downloaded package into the `<`[`TeamCity Data Directory`](teamcity-data-directory.md)`>/lib/jdbc` directory.
 
 <note>
 
-Note that Microsoft JDBC driver v6.0\+ has compatibility issues with Microsoft SQL Server 2005. For MS SQL Server 2005, use [JDBC driver v4.0](https://www.microsoft.com/en-us/download/details.aspx?id=54629) (`exe` or `.tar.gz` depending on your TeamCity server platform).
+Note that Microsoft JDBC driver v6.0\+ has compatibility issues with Microsoft SQL Server 2005. For MS SQL Server 2005, use [JDBC driver v4.x](https://docs.microsoft.com/en-us/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server) (`exe` or `.tar.gz` depending on your TeamCity server platform).
 
 </note>
 


### PR DESCRIPTION
The "### Set up JDBC Driver for SQL Server database" section is outdated in 2019.1 branch.
The link from step 1 (Download the Microsoft JDBC driver v6.0+) used to point to version 6.0, but now it points to version 6.2 on Microsoft site. This causes problem with step 3 where it says:
In step 3 it says "Copy the sqljdbc42.jar" and is 6.2 the name of the jar is different. There is actually two of them: 
mssql-jdbc-6.2.2.jre7.jar
mssql-jdbc-6.2.2.jre8.jar

I changed the Microsoft JDBC driver link to point to the page with different driver versions to let the user pick. In step 3 I added the correction for the new jar file naming inside the downloaded package.

Please review/change as necessary.