### PR TITLE
Fix wrong notification templates location path

### DIFF
--- a/topics/customizing-notifications.md
+++ b/topics/customizing-notifications.md
@@ -24,7 +24,7 @@ The output values defined by the template are then used by the notifier to send 
 
 ### Notification Templates Location
 
-Each of the bundled [notifiers](notifier.md) has a directory in \<[TeamCity Data Directory](teamcity-data-directory.md)\>\/config_notifications/, which stores [FreeMarker](http://freemarker.sourceforge.net/) (`.ftl`) templates. There are also [`.dist`](teamcity-data-directory.md#.dist+Template+Configuration+Files) files that store the default templates. Each notification type evaluates a template file with a corresponding name. The template files can be modified while the server is running.
+Each of the bundled [notifiers](notifier.md) has a directory in \<[TeamCity Data Directory](teamcity-data-directory.md)\>\/config\/_notifications/, which stores [FreeMarker](http://freemarker.sourceforge.net/) (`.ftl`) templates. There are also [`.dist`](teamcity-data-directory.md#.dist+Template+Configuration+Files) files that store the default templates. Each notification type evaluates a template file with a corresponding name. The template files can be modified while the server is running.
 
 By default, the server checks for changes in the files every 60 seconds, but this can be changed by setting the `teamcity.notification.template.update.interval` [internal property](configuring-teamcity-server-startup-properties.md#TeamCity+internal+properties) to the desired number of seconds.
 


### PR DESCRIPTION
The slash is missing between `config` and `_notifications`.