### PR TITLE
Clarifications about automatic cert delivering

### DIFF
--- a/topics/uploading-ssl-certificates.md
+++ b/topics/uploading-ssl-certificates.md
@@ -14,7 +14,7 @@ __To add a trusted certificate__
 
 ### Delivering certificates to TeamCity agents
 
-All uploaded certificates will be automatically delivered to all TeamCity agents.
+All uploaded certificates will be automatically delivered to TeamCity agent upon running a build, and saved under `<`[`TeamCity Agent Home`](agent-home-directory.md)`>/system/serverTrustedCertificates`.
 
 However, sometimes automatically distributing certificates to all agents may not be needed or may be undesirable. Then you can __manually__ add certificates to a required agent by placing them into the `<`[`TeamCity Agent Home`](agent-home-directory.md)`>/conf/trustedCertificates` folder (one file per certificate, certificates in textual form in one of the supported formats mentioned above).
 

--- a/topics/uploading-ssl-certificates.md
+++ b/topics/uploading-ssl-certificates.md
@@ -1,7 +1,7 @@
 [//]: # (title: Uploading SSL Certificates)
 [//]: # (auxiliary-id: Uploading SSL Certificates)
 
-It is possible to upload an SSL certificate which TeamCity considers trusted when establishing connection by HTTPS or SSL protocols. These can be self\-signed certificates or certificates signed by a not well\-known certificate authority (CA).
+It is possible to upload an SSL certificate which TeamCity considers trusted when establishing connection by HTTPS or SSL protocols. These can be self-signed certificates or certificates signed by a not well-known certificate authority (CA).
 
 ### Adding trusted certificates to TeamCity server
 
@@ -9,28 +9,16 @@ The trusted certificates storage is global for the whole server and affects all 
 
 __To add a trusted certificate__
 1. Navigate to the Root project __Administration__ area and select the __SSL / HTTPS Certificates__ menu item in the sidebar
-2. Click __Upload certificate__, specify the certificate name and choose a certificate file of one of the __supported formats__: PEM, DER or PKCS#7.
+2. Click __Upload certificate__, specify the certificate name, and choose a certificate file of one of the __supported formats__: PEM, DER, or PKCS#7.
 3. Save your changes.
 
 ### Delivering certificates to TeamCity agents
 
-All uploaded certificates will be automatically delivered to TeamCity agent upon running a build, and saved under `<`[`TeamCity Agent Home`](agent-home-directory.md)`>/system/serverTrustedCertificates`.
-
+All uploaded certificates will be automatically delivered to each TeamCity agent upon running the next build on it and saved under its  `<`[`TeamCity Agent Home`](agent-home-directory.md)`>/system/serverTrustedCertificates`.   
 However, sometimes automatically distributing certificates to all agents may not be needed or may be undesirable. Then you can __manually__ add certificates to a required agent by placing them into the `<`[`TeamCity Agent Home`](agent-home-directory.md)`>/conf/trustedCertificates` folder (one file per certificate, certificates in textual form in one of the supported formats mentioned above).
 
 This can be useful in the following cases:
-* If the user is running the TeamCity server under a non\-trusted certificate, you need to place the server certificate into this folder on an agent to establish agent\-server connection
+* If the user is running the TeamCity server under a non-trusted certificate, you need to place the server certificate into this folder on an agent to establish agent-server connection.
 * If the user considers their network connection between the server and agents insecure and does not want to transfer sensitive information.
 
 __ __
-
-<br/>
-<br/>
-<br/>
-<br/>
-<br/>
-<br/>
-<br/>
-<br/>
-<br/>
-<br/>


### PR DESCRIPTION
Add the location where certificates are saved on the agent upon being automatically delivered.
Clarify that the certificates are only delivered upon running a build, and not right after they are uploaded to the server.