### PR TITLE
Change Integration with VCS Hosting Services page

### DIFF
--- a/topics/integrating-teamcity-with-vcs-hosting-services.md
+++ b/topics/integrating-teamcity-with-vcs-hosting-services.md
@@ -31,11 +31,11 @@ The following steps are performed in your GitHub account:
 5. Save the connection settings. 
 6. The connection is configured, and now a small GitHub icon becomes active in several places where a repository URL can be specified: [create project from URL](creating-and-editing-projects.md#Creating+project+pointing+to+repository+URL), [create VCS root from URL](guess-settings-from-repository-url.md), create [Git](git.md) VCS root, create [GitHub](github.md) issue tracker. Click the icon, log in to GitHub and authorize TeamCity. The authorized application will be granted full control of private repositories and the _Write repository hooks_ permission.
 
-### Connecting to Bitbucket
+### Connecting to Bitbucket Cloud
 
-You need to configure a connection to your public Bitbucket repository to create a [project from URL](creating-and-editing-projects.md#Creating+project+pointing+to+repository+URL), create a [VCS root from URL](guess-settings-from-repository-url.md), create a [Mercurial](mercurial.md) VCS root, or create a [Bitbucket](bitbucket-cloud.md) issue tracker.
+You need to configure a connection to your public Bitbucket Cloud repository to create a [project from URL](creating-and-editing-projects.md#Creating+project+pointing+to+repository+URL), create a [VCS root from URL](guess-settings-from-repository-url.md), create a [Mercurial](mercurial.md) VCS root, or create a [Bitbucket](bitbucket-cloud.md) issue tracker.
 
-To configure a Bitbucket connection:
+To configure a Bitbucket Cloud connection:
 1. In __Project Administration | Connections__, click __Add Connection__.
 2. Select _Bitbucket_ as the connection type.   
 The page that opens provides the parameters to be used when registering an OAuth consumer on Bitbucket Cloud. Click the _register application_ link.   
@@ -47,7 +47,7 @@ You need to create an [OAuth consumer](https://confluence.atlassian.com/bitbucke
    5. On the page that opens, in the __OAth consumers__ section, click the name of your TeamCity application to display the key and the secret.
 3. Continue configuring the connection in TeamCity: on the __Add Connection__ page that is open, specify the key and secret.
 4. Save the connection settings. 
-5. The connection is configured, and now a small Bitbucket icon becomes active in several places where a repository URL can be specified: [create project from URL](creating-and-editing-projects.md#Creating+project+pointing+to+repository+URL), [create VCS root from URL](guess-settings-from-repository-url.md), create [Mercurial](mercurial.md) VCS root, create [Bitbucket](bitbucket-cloud.md) issue tracker. Click the icon, log in to Bitbucket  and authorize TeamCity. TeamCity will be granted access to your public repositories. For __private__ repositories you'll still have to sign in to Bitbucket as it doesn't provide non\-expiring access tokens. See the [related discussion](https://bitbucket.org/site/master/issues/11774/application-specific-passwords-or-tokens).
+5. The connection is configured, and now a small Bitbucket icon becomes active in several places where a repository URL can be specified: [create project from URL](creating-and-editing-projects.md#Creating+project+pointing+to+repository+URL), [create VCS root from URL](guess-settings-from-repository-url.md), create [Mercurial](mercurial.md) VCS root, create [Bitbucket](bitbucket-cloud.md) issue tracker. Click the icon, log in to Bitbucket  and authorize TeamCity. TeamCity will be granted access to your public repositories. For __private__ repositories you'll still have to provide Bitbucket credentials to be used for authentication by TeamCity, as Bitbucket Cloud doesn't provide non\-expiring access tokens. See the [related discussion](https://bitbucket.org/site/master/issues/11774/application-specific-passwords-or-tokens).
 
 ### Connecting to GitLab
 


### PR DESCRIPTION
- change Bitbucket to Bitbucket Cloud;
- rephrase the sentence about providing credentials after obtaining a repository URL via Bitbucket Cloud Connection.