### PR TITLE
Update multinode-setup.md

### DIFF
--- a/topics/multinode-setup.md
+++ b/topics/multinode-setup.md
@@ -4,7 +4,7 @@
 TeamCity allows configuring and starting one or more secondary server instances (nodes) in addition to the main one. The main and secondary nodes operate under the same license and share the TeamCity Data Directory and the database.
 
 Using the multinode setup, you can:
-* Set up a high-availability TeamCity installation that will have zero downtime for most responsibilities. Secondary nodes will operate [as usual](#user-actions) during the downtime of the main server (for example, during the minor upgrades).
+* Set up a high-availability TeamCity installation that will have zero downtime for most operations. Secondary nodes will operate [as usual](#user-actions) during the downtime of the main server (for example, during the minor upgrades).
 * Improve the performance of the main server by delegating tasks to the secondary nodes. A secondary node can detect new commits and process data produced by running builds (build logs, artifacts, statistic values).
 
 <anchor name="user-actions"/>

--- a/topics/multinode-setup.md
+++ b/topics/multinode-setup.md
@@ -4,7 +4,7 @@
 TeamCity allows configuring and starting one or more secondary server instances (nodes) in addition to the main one. The main and secondary nodes operate under the same license and share the TeamCity Data Directory and the database.
 
 Using the multinode setup, you can:
-* Set up a high-availability TeamCity installation that will have zero downtime. Secondary nodes will operate [as usual](#user-actions) during the downtime of the main server (for example, during the minor upgrades).
+* Set up a high-availability TeamCity installation that will have zero downtime for most responsibilities. Secondary nodes will operate [as usual](#user-actions) during the downtime of the main server (for example, during the minor upgrades).
 * Improve the performance of the main server by delegating tasks to the secondary nodes. A secondary node can detect new commits and process data produced by running builds (build logs, artifacts, statistic values).
 
 <anchor name="user-actions"/>


### PR DESCRIPTION
Clarifying that the multinode setup is not presently true high-availability. There are some responsibilities that will be unavailable while the primary node is down.