### PR TITLE
MySQL charset recommendations

### DIFF
--- a/topics/common-problems.md
+++ b/topics/common-problems.md
@@ -426,12 +426,12 @@ For __MySQL 5.7\+ and MariaDB 10.2\+__ use the defaults, no changes are required
 
 ### 'Incorrect string value' error in MySQL
 
-1. Use the `utf8mb4` character set in MySQL and set up the MySQL server to use `utf8mb4` by default using the following options in the `[mysqld]` section in `my.cnf`: 
-
+1. Make sure the database uses the `utf8mb4` character set and `utf8mb4_bin` collation. If that's not the case, [change the DB character set and collation](#Resolve+character+set%2Fcollation-related+problems).
+2. If the character set and collation are set properly, but the new errors still occur, the problem is that default charset in MySQL is not utf8mb4. Set up the MySQL server to use `utf8mb4` by default using the following options in the `[mysqld]` section in `my.cnf`: 
     `character_set_server = utf8mb4`   
     `collation_server = utf8mb4_bin`
     
-2.  Restart MySQL for the changes to `my.cnf` to take effect.
+3.  Restart MySQL for the changes to `my.cnf` to take effect.
 
 ### 'This driver is not configured for integrated authentication' error with MS SQL database
 

--- a/topics/common-problems.md
+++ b/topics/common-problems.md
@@ -427,11 +427,10 @@ For __MySQL 5.7\+ and MariaDB 10.2\+__ use the defaults, no changes are required
 ### 'Incorrect string value' error in MySQL
 
 1. Make sure the database uses the `utf8mb4` character set and `utf8mb4_bin` collation. If that's not the case, [change the DB character set and collation](#Resolve+character+set%2Fcollation-related+problems).
-2. If the character set and collation are set properly, but the new errors still occur, the problem is that default charset in MySQL is not utf8mb4. Set up the MySQL server to use `utf8mb4` by default using the following options in the `[mysqld]` section in `my.cnf`: 
+2. If the character set and collation are set properly, but the new errors still occur, the problem is that the default charset in MySQL is not utf8mb4. Set up the MySQL server to use `utf8mb4` by default by specifying the following options in the `[mysqld]` section of `my.cnf`:  
     `character_set_server = utf8mb4`   
     `collation_server = utf8mb4_bin`
-    
-3.  Restart MySQL for the changes to `my.cnf` to take effect.
+3. Restart MySQL for the changes in `my.cnf` to take effect.
 
 ### 'This driver is not configured for integrated authentication' error with MS SQL database
 

--- a/topics/configuring-utf8-character-set-for-mysql.md
+++ b/topics/configuring-utf8-character-set-for-mysql.md
@@ -9,7 +9,7 @@ To create a MySQL database which uses the UTF-8 character set:
 1. Create a new database:
 
     ```SQL
-    create database <database_name> character set UTF8 collate utf8_bin
+    create database <database_name> character set utf8mb4 collate utf8mb4_bin
     ```
 	
 2. Open `<[TeamCity Data Directory](teamcity-data-directory.md)>/config/database.properties`, and add the `characterEncoding` property:

--- a/topics/setting-up-an-external-database.md
+++ b/topics/setting-up-an-external-database.md
@@ -59,7 +59,7 @@ The section below describes the required configuration on the database server an
 
 Recommended database server settings:
  * use InnoDB storage engine
- * use [utf8mb4 character set](configuring-utf8-character-set-for-mysql.md) (or utf8 if MySQL version is 5.5.2 or older)
+ * use [utf8mb4 character set](configuring-utf8-character-set-for-mysql.md) (or utf8 if MySQL version is 5.5.2 or earlier)
  * use case\-sensitive collation
  * make sure that the time zone of the JVM running TeamCity and that of MySQL instance are the same using the `my.cnf` file or by configuring time zones at the OS level
  * [see also recommendations for MySQL server settings](how-to.md#Configure+Newly+Installed+MySQL+Server)
@@ -68,7 +68,7 @@ The MySQL user account that will be used by TeamCity must be granted all permiss
 
 
 ```sql
-create database <database-name> collate utf8mb4_bin; -- or utf8_bin on MySQL 5.5.2 and older
+create database <database-name> collate utf8mb4_bin; -- or utf8_bin on MySQL 5.5.2 or earlier
 create user <user-name> identified by '<password>';
 grant all privileges on <database-name>.* to <user-name>;
 grant process on *.* to <user-name>;

--- a/topics/setting-up-an-external-database.md
+++ b/topics/setting-up-an-external-database.md
@@ -59,7 +59,7 @@ The section below describes the required configuration on the database server an
 
 Recommended database server settings:
  * use InnoDB storage engine
- * use [UTF-8 character set](configuring-utf8-character-set-for-mysql.md)
+ * use [utf8mb4 character set](configuring-utf8-character-set-for-mysql.md) (or utf8 if MySQL version is 5.5.2 or older)
  * use case\-sensitive collation
  * make sure that the time zone of the JVM running TeamCity and that of MySQL instance are the same using the `my.cnf` file or by configuring time zones at the OS level
  * [see also recommendations for MySQL server settings](how-to.md#Configure+Newly+Installed+MySQL+Server)
@@ -68,7 +68,7 @@ The MySQL user account that will be used by TeamCity must be granted all permiss
 
 
 ```sql
-create database <database-name> collate utf8_bin;
+create database <database-name> collate utf8mb4_bin; -- or utf8_bin on MySQL 5.5.2 and older
 create user <user-name> identified by '<password>';
 grant all privileges on <database-name>.* to <user-name>;
 grant process on *.* to <user-name>;


### PR DESCRIPTION
Current documentation still recommends `utf8` collation for MySQL DB which can cause 'Incorrect string value' error in MySQL ([TW-24086](https://youtrack.jetbrains.com/issue/TW-24086)). I propose to recommend `utf8mb4` as per [this comment](https://youtrack.jetbrains.com/issue/TW-61329#focus=Comments-27-3745757.0-0).

Also, the 'Incorrect string value' description in common problems gives an impression that existing DB's collation can be changed by editing `my.cnf`. Let us state explicitly that the existing DB collation still needs to be configured properly. [Related slack thread](https://jetbrains.slack.com/archives/C0318RLTD/p1615826769139100).