### PR TITLE
Changed 'buildtype-graphs' type using lower case t

### DIFF
--- a/topics/custom-chart.md
+++ b/topics/custom-chart.md
@@ -42,7 +42,7 @@ Each extension must have a unique `id` in the project.
 
 The `type` attribute is set to 
 * `project-graphs` for project-level chart
-* `buildType-graphs` for build configuration-level chart
+* `buildtype-graphs` for build configuration-level chart
 
 Each chart is described by the `<parameters>` element. It must contain the `<param>` sub-elements with data shown in the chart in `name/value` pairs; the `series` parameter uses the JSON format to list series of data shown on the chart. 
 


### PR DESCRIPTION
Changed 'buildtype-graphs' type using lower case t as mentioned in the xml example. I was cracking my head around this quite some time wondering why I don't get graphs generated till I realized that the type in the actual xml needs to be lower case (I initially copied it from the text and not the xml).  To avoid this potential confusion for others I propose to change the case in the description as well.