### PR TITLE
Fix typo in 'git sparce-checkout'

### DIFF
--- a/topics/git.md
+++ b/topics/git.md
@@ -914,7 +914,7 @@ The idle timeout for the `git fetch` operation when the agent-side checkout is u
 ## Limitations
 {id="Limitations"}
 
-The Git plugin uses [`git sparce-checkout`](https://git-scm.com/docs/git-sparse-checkout#_sparse_checkout) to check out Git files on an agent. The plugin is able to perform only simple file mapping operations which limits the set of supported [VCS checkout rules](vcs-checkout-rules.md) for Git.
+The Git plugin uses [`git sparse-checkout`](https://git-scm.com/docs/git-sparse-checkout#_sparse_checkout) to check out Git files on an agent. The plugin is able to perform only simple file mapping operations which limits the set of supported [VCS checkout rules](vcs-checkout-rules.md) for Git.
 
 The following rules are supported:
 


### PR DESCRIPTION
Should be 'git sparse-checkout'