### PR TITLE
Fix release notes link for 2021.1 version

### DIFF
--- a/topics/previous-releases-downloads.md
+++ b/topics/previous-releases-downloads.md
@@ -30,7 +30,7 @@ Build 92597
 [Windows installer](https://download.jetbrains.com/teamcity/TeamCity-2021.1.1.exe)   
 [Archive with bundled Tomcat (any platform)](https://download.jetbrains.com/teamcity/TeamCity-2021.1.1.tar.gz)
 
-[Release notes](teamcity-2021-1-1-release-notes.md)
+[Release notes](teamcity-2021-1-release-notes.md)
 
 ## TeamCity 2020.2.4
 


### PR DESCRIPTION
Currently, the link points to release notes for 2021.1.1