### PR TITLE
a little material about GitLab permissions

### DIFF
--- a/topics/commit-status-publisher.md
+++ b/topics/commit-status-publisher.md
@@ -48,6 +48,8 @@ If you use a recent version of GitLab (\<= 9.0), it is recommended to use the Gi
 
 For older versions of GitLab, use the GitLab URL of the format `http[s]://<hostname>[:<port>]/api/v3`.
 
+The GitLab credentials for Commit Status Publisher must belong to a user with a Developer, Maintainer, or Owner role for the project. In addition, to change a commit status for a protected branch, the GitLab user must be included in the **Allowed to push** list.
+
 ### Bitbucket Cloud
 
 To be able to connect to Bitbucket Cloud, make sure the [TeamCity server URL](configuring-server-url.md) is a fully qualified domain name (FQDN): for example, [`http://myteamcity.domain.com:8111`](http://myteamcity.domain.com:8111){nullable="true"}. Short names, such as [`http://myteamcity:8111`](http://myteamcity:8111){nullable="true"}, are rejected by the Bitbucket API.


### PR DESCRIPTION
Other provider sections mention required token scopes, so required role permissions are maybe similarly helpful. GitLab documentation does show role permissions required to change a status, but it is inside a big table: https://docs.gitlab.com/ee/user/permissions.html#project-members-permissions Also they don't seem to explicitly mention that push access is needed for commit status changes on protected branches, but that inference might be intuitive enough for most users.