### PR TITLE
Clarify which test methods run in parallel

### DIFF
--- a/topics/parallel-tests.md
+++ b/topics/parallel-tests.md
@@ -13,6 +13,8 @@ In TeamCity 2022.04, the tests' distribution logic is provided by TeamCity itsel
 The new _Parallel tests_ build feature solves the task of parallel tests execution on different agents.
 To enable this feature in an existing build configuration which is already configured to run build steps with tests, go to **Build Configuration Settings | Build Features**, click **Add build feature**, and choose the _Parallel tests_ type. You will be prompted to set the number of batches, which also means the number of parallel agents to use in a build.
 
+> Note: only tests methods from different classes (or test cases) can run in parallel on different agents.
+
 Before TeamCity splits tests into batches to run in parallel, it needs to gather test statistics of at least one preceding build. This information helps subdivide tests in semi-equally sized batches (based on tests duration) so that the total build time is as short as possible.
 If you enable this feature in a freshly added build configuration, its first build will run in the normal mode; when it finishes and produces test reports, TeamCity will be able to split the second one.
 


### PR DESCRIPTION
Currently, we only say that only test methods from different classes/cases can run in parallel at the end of the article in the 'Custom execution of parallelized tests﻿' section. Should we give that info in the overview of how the feature works?