### PR TITLE
Update build-checkout-directory.md

### DIFF
--- a/topics/build-checkout-directory.md
+++ b/topics/build-checkout-directory.md
@@ -62,9 +62,7 @@ The time frame for automatic directory expiration can be changed by specifying a
 
 _Expiration-based directory cleaning_ is performed in the background when build agent is idle (i.e. no builds are running).
 
-The _lifetime_ of a checkout directory is reflected in the `work/directory.map` file. Rows in the file correspond to existing checkout directories (one to one). Last value in each row represents the number of hours before that particular directory is cleaned up. By default, the value is set to 192 hours (8 days) for each directory (parameter value: `default`).
-
-You can override the default value by specifying the abovementioned parameters, but bear in mind that the change will only apply to all _newly created_ directories, meaning that all existing directories will retain their respective lifetime values.
+Bear in mind that once the parameter is set, the change will only apply to all _newly executed builds_. For older checkout directories, where no new builds were executed after specifying the parameter, the _expiration_ value will remain as it was before the change.
 
  <seealso>
         <category ref="admin-guide">

--- a/topics/build-checkout-directory.md
+++ b/topics/build-checkout-directory.md
@@ -60,7 +60,11 @@ The time frame for automatic directory expiration can be changed by specifying a
    * `never` will let TeamCity know that the directory should never be deleted by TeamCity 
    * `default` will enforce using the default value
 
-Expiration-based directory cleaning is performed in the background when the build agent is idle (no builds are running).
+_Expiration-based directory cleaning_ is performed in the background when build agent is idle (i.e. no builds are running).
+
+The _lifetime_ of a checkout directory is reflected in the `work/directory.map` file. Rows in the file correspond to existing checkout directories (one to one). Last value in each row represents the number of hours before that particular directory is cleaned up. By default, the value is set to 192 hours (8 days) for each directory (parameter value: `default`).
+
+You can override the default value by specifying the abovementioned parameters, but bear in mind that the change will only apply to all _newly created_ directories, meaning that all existing directories will retain their respective lifetime values.
 
  <seealso>
         <category ref="admin-guide">


### PR DESCRIPTION
Clarify how the cleanup process works. It may be unclear to the users why some of the directories are still not cleaned up even after setting the parameter.