### PR TITLE
Minor - update what's new

### DIFF
--- a/topics/what-s-new-in-teamcity.md
+++ b/topics/what-s-new-in-teamcity.md
@@ -115,7 +115,7 @@ Starting with version 2023.05, you can connect to image registries, run build st
 <img src="dk-podman-wn.png" width="706" alt="Podman support in TeamCity 2023.05"/>
 
 * The [](container-wrapper.md) extension (previously known as "Docker Wrapper") now pulls images via either `docker pull` or `podman pull`, depending on which Container Manager is installed on the build agent.
-* The [](docker-support.md) build feature (previously known as "Docker Support") can now use Podman to log in to container registries.
+* The [](docker-support.md) build feature can now use Podman to log in to container registries.
 * If you use the [](command-line.md) runner to execute `podman ...` commands, utilize new `container.engine`, `podman.version`, and `podman.osType` [parameters](configuring-build-parameters.md) to specify [agent requirements](agent-requirements.md) that ensure your builds run only on build agents with installed Podman.
 
 Learn more: [](integrating-teamcity-with-container-managers.md).


### PR DESCRIPTION
`[](docker-support.md) build feature (previously known as "Docker Support")` renders as `Docker Support build feature (previously known as "Docker Support")`.