### PR TITLE
TW-83371 Upgrade note about updating .NET SDK from 5.0 to 7.0

### DIFF
--- a/topics/known-issues.md
+++ b/topics/known-issues.md
@@ -450,10 +450,6 @@ In rare cases, if an early build of Visual Studio 2017 is installed on your buil
 
 To work around this problem, you can upgrade Visual Studio 2017 to the latest build or, alternatively, install any later version of .NET Framework.
 
-### Compatibility with Visual Studio Build Tools 17.2.0 and .NET SDK 6.0.300
-
-At the moment, TeamCity 2022.04 does not support the recently released Visual Studio Build Tools 17.2.0 and .NET SDK 6.0.300. To solve the problem, install the plugin from [the related issue](https://youtrack.jetbrains.com/issue/TW-76189/Tests-error-with-The-argument-noconsolelogger-is-invalid-with-NE#focus=Comments-27-6067187.0-0). The fix will be included in TeamCity 2022.04.1.
-
 ### Parsing .rsp files (Error MSB1006: Property is not valid)
 
 Due to the [breaking change](https://github.com/dotnet/command-line-api/pull/1714) introduced by Microsoft in the core `System.CommandLine` library, .rsp files with commas and (or) semicolons in property values are parsed incorrectly. To ensure this issue does not occur, enclose values of [system properties](configuring-build-parameters.md#System+Properties) in quotes. If this solution is not applicable to your project, add the `teamcity.internal.dotnet.msbuild.parameters.escape` configuration parameter and set its value to _"true"_. With this setting enabled, TeamCity automatically wraps values of user-defined properties in quotes.

--- a/topics/upgrade-notes.md
+++ b/topics/upgrade-notes.md
@@ -8,9 +8,11 @@
 {id="bundled-tools-updates-2023-11"}
 
 * The version of .NET SDK bundled with the TeamCity Docker images has been updated from 5.0 to 7.0.
-If you need an earlier version of .NET SDK (for example, .NET Core 3.1 or .NET SDK 5.0), we recommend that you build your own Docker image using the provided TeamCity Docker base image (`jetbrains/teamcity-minimal-agent`).
-See the [README](https://github.com/JetBrains/teamcity-docker-images#readme) file in the `teamcity-docker-images` repository for more details.
+* .NET Core 3.1 is no longer bundled with the TeamCity Docker images.
 
+> If you need an earlier version of .NET SDK (for example, .NET Core 3.1 or .NET SDK 5.0), we recommend that you build your own Docker image using the provided TeamCity Docker base image (`jetbrains/teamcity-minimal-agent`).
+> See the [README](https://github.com/JetBrains/teamcity-docker-images#readme) file in the `teamcity-docker-images` repository for more details.
+{type="note"}
 
 ## Changes from 2023.05.3 to 2023.05.4
 

--- a/topics/upgrade-notes.md
+++ b/topics/upgrade-notes.md
@@ -4,6 +4,11 @@
 
 ## Changes from 2023.05.4 to 2023.11
 
+### Bundled Tools Updates
+{id="bundled-tools-updates-2023-11"}
+
+* The version of .NET SDK bundled with the TeamCity Docker images has been updated from version 5.0 to 7.0.
+If you need an earlier version of .NET SDK (for example, .NET Core 3.1 or .NET SDK 5.0), we recommend that you build your own Docker image for .NET runner using the provided TeamCity Docker base image.
 
 
 ## Changes from 2023.05.3 to 2023.05.4

--- a/topics/upgrade-notes.md
+++ b/topics/upgrade-notes.md
@@ -9,10 +9,10 @@
 
 * The version of .NET SDK bundled with the TeamCity Docker images has been updated from 5.0 to 7.0.
 * .NET Core 3.1 is no longer bundled with the TeamCity Docker images.
-
-> If you need an earlier version of .NET SDK (for example, .NET Core 3.1 or .NET SDK 5.0), we recommend that you build your own Docker image using the provided TeamCity Docker base image (`jetbrains/teamcity-minimal-agent`).
-> See the [README](https://github.com/JetBrains/teamcity-docker-images#readme) file in the `teamcity-docker-images` repository for more details.
-{type="note"}
+  > If you need an earlier version of .NET SDK (for example, .NET Core 3.1 or .NET SDK 5.0), we recommend that you build your own Docker image using the provided TeamCity Docker base image (`jetbrains/teamcity-minimal-agent`).
+  > See the [README](https://github.com/JetBrains/teamcity-docker-images#readme) file in the `teamcity-docker-images` repository for more details.
+  > 
+  {type="note"}
 
 ## Changes from 2023.05.3 to 2023.05.4
 

--- a/topics/upgrade-notes.md
+++ b/topics/upgrade-notes.md
@@ -7,8 +7,9 @@
 ### Bundled Tools Updates
 {id="bundled-tools-updates-2023-11"}
 
-* The version of .NET SDK bundled with the TeamCity Docker images has been updated from version 5.0 to 7.0.
-If you need an earlier version of .NET SDK (for example, .NET Core 3.1 or .NET SDK 5.0), we recommend that you build your own Docker image for .NET runner using the provided TeamCity Docker base image.
+* The version of .NET SDK bundled with the TeamCity Docker images has been updated from 5.0 to 7.0.
+If you need an earlier version of .NET SDK (for example, .NET Core 3.1 or .NET SDK 5.0), we recommend that you build your own Docker image using the provided TeamCity Docker base image (`jetbrains/teamcity-minimal-agent`).
+See the [README](https://github.com/JetBrains/teamcity-docker-images#readme) file in the `teamcity-docker-images` repository for more details.
 
 
 ## Changes from 2023.05.3 to 2023.05.4


### PR DESCRIPTION
Issue: [TW-83371](https://youtrack.jetbrains.com/issue/TW-83371)
Preview: https://helpserver.labs.jb.gg/help/teamcity/TW-83371/upgrade-notes.html

An upgrade note for upgrading from 2023.05 -> 2023.11 was added. This note will be invisible in the 2023.09 cloud release, because the Upgrade Notes article is not published in the Cloud docs.