### PR TITLE
Fix the link the link in Adding Custom Build Metric paragraph

### DIFF
--- a/topics/build-failure-conditions.md
+++ b/topics/build-failure-conditions.md
@@ -101,7 +101,7 @@ By default, TeamCity provides the wide range of _build metrics_:
 
 You can add your own build metric. There are two ways to do it:
 
-- Use Kotlin DSL to configure a build failure condition [on a custom statistic value](build-failure-conditions.md#Adding+Custom+Build+Metric)
+- Use Kotlin DSL to configure a build failure condition [on a custom statistic value](teamcity-info-xml#Reporting+Custom+Statistics)
 reported by the build.
 
    The sample Kotlin DSL code is as follows:

--- a/topics/build-failure-conditions.md
+++ b/topics/build-failure-conditions.md
@@ -101,7 +101,7 @@ By default, TeamCity provides the wide range of _build metrics_:
 
 You can add your own build metric. There are two ways to do it:
 
-- Use Kotlin DSL to configure a build failure condition [on a custom statistic value](teamcity-info-xml#Reporting+Custom+Statistics)
+- Use Kotlin DSL to configure a build failure condition [on a custom statistic value](teamcity-info-xml.md#Reporting+Custom+Statistics)
 reported by the build.
 
    The sample Kotlin DSL code is as follows:


### PR DESCRIPTION
Previously the link led to the same paragraph where it is located, making the whole article confusing. It was not clear how one can report custom statistics during a build.