### PR TITLE
Update inspections-resharper.md

### DIFF
--- a/topics/inspections-resharper.md
+++ b/topics/inspections-resharper.md
@@ -268,6 +268,12 @@ If a build has too many inspection errors or warnings, you can configure it to f
 
 In order to have adequate inspections' execution results, you may need to __build your solution before running analysis__. This pre-step is especially actual when you use (implicitly or explicitly) __code generation__ in your project.
 
+<note>
+ 
+Starting from version 2021.2, R# InspectCode builds the target solution by default before starting the analysis.
+
+</note>
+
 ### Bundled ReSharper Versions
 
 <table><tr>
@@ -387,6 +393,62 @@ ReSharper Version
 <td>
 
 2021.1.2
+
+</td></tr>
+
+<tr>
+
+<td>
+
+2022.04
+
+</td>
+
+<td>
+
+2021.1.2
+
+</td></tr>
+
+<tr>
+
+<td>
+
+2022.10
+
+</td>
+
+<td>
+
+2021.1.2
+
+</td></tr>
+
+<tr>
+
+<td>
+
+2023.05
+
+</td>
+
+<td>
+
+2021.1.2
+
+</td></tr>
+
+<tr>
+
+<td>
+
+2023.11
+
+</td>
+
+<td>
+
+2023.1.1
 
 </td></tr>
 


### PR DESCRIPTION
1. Add a note, that R# InspectCode builds the target solution by default before starting the analysis and one does not need to build it in a separate step anymore
2. Update the table of bundled tool versions for new TeamCity releases