### PR TITLE
changed bundled R# CTL tool version for 2023.11

### DIFF
--- a/topics/inspections-resharper.md
+++ b/topics/inspections-resharper.md
@@ -448,7 +448,7 @@ ReSharper Version
 
 <td>
 
-2023.1.1
+2023.2.1
 
 </td></tr>
 


### PR DESCRIPTION
bundled R# CTL is changed one more time, see https://youtrack.jetbrains.com/issue/TW-78248/Deprecate-Duplicates-finder-ReSharper-runner-and-update-bundled-version-of-JetBrains-ReSharper-Command-Line-Tools#focus=Comments-27-8166314.0-0