### PR TITLE
clarify build id

### DIFF
--- a/topics/build-results-page.md
+++ b/topics/build-results-page.md
@@ -7,9 +7,18 @@ This article gives an overview of the __Build Results__ page of the new TeamCity
 
 ## Internal Build ID
 
-The URL of the __Build Results__ page typically looks like the following: `<server_URL>/buildConfiguration/<BuildConfiguration_ID>/<build_ID>?...`. The numeric `build_ID` value is the internal build ID that uniquely identifies this build in TeamCity. This value can be denoted by the `buildId` parameter. You can also find the same value under the build's **Parameters** tab in TeamCity UI, stored in the `teamcity.build.id` parameter.
+Knowing a build ID can be required when working with [REST API](https://www.jetbrains.com/help/teamcity/rest/teamcity-rest-api-documentation.html) or [downloading build artifacts](patterns-for-accessing-build-artifacts.md). You can obtain this ID from the URL or the **Parameters** tab of the __Build Results__ page.
 
-Knowing a build ID can be required when working with [REST API](https://www.jetbrains.com/help/teamcity/rest/teamcity-rest-api-documentation.html) or [downloading build artifacts](patterns-for-accessing-build-artifacts.md).
+The URL of the __Build Results__ page typically looks like the following:
+
+* In Sakura UI: `<SERVER_URL>/buildConfiguration/<CONFIGURATION_ID>/<BUILD_ID>?...`.
+* In Classic UI: `<SERVER_URL>/viewLog.html?buildId=<BUILD_ID>&buildTypeId=<CONFIGURATION_ID>&...`
+
+The `<BUILD_ID>` portion is the internal numeric build ID uniquely identifying this build in TeamCity.
+
+You can also find the same value under the build's **Parameters** tab in TeamCity UI, stored in the `teamcity.build.id` parameter.
+
+
 
 ## Build Results Title Panel
 

--- a/topics/build-results-page.md
+++ b/topics/build-results-page.md
@@ -7,7 +7,7 @@ This article gives an overview of the __Build Results__ page of the new TeamCity
 
 ## Internal Build ID
 
-In the URL of the __Build Results__ page, you can find the parameter `buildId` with a numeric value. This number is the internal build ID uniquely identifying the build in the TeamCity installation. You might need this ID when composing a URL manually. For example, for [REST API](https://www.jetbrains.com/help/teamcity/rest/teamcity-rest-api-documentation.html) requests or when [downloading build artifacts](patterns-for-accessing-build-artifacts.md).
+In the URL of the __Build Results__ page, you can find a numeric value. It may be denoted by the parameter `buildId`. It is also found on the build's Parameters tab denoted by the `teamcity.build.id` key. This number is the internal build ID uniquely identifying the build in the TeamCity installation. You might need this ID when composing a URL manually. For example, for [REST API](https://www.jetbrains.com/help/teamcity/rest/teamcity-rest-api-documentation.html) requests or when [downloading build artifacts](patterns-for-accessing-build-artifacts.md).
 
 ## Build Results Title Panel
 

--- a/topics/build-results-page.md
+++ b/topics/build-results-page.md
@@ -7,7 +7,9 @@ This article gives an overview of the __Build Results__ page of the new TeamCity
 
 ## Internal Build ID
 
-In the URL of the __Build Results__ page, you can find a numeric value. It may be denoted by the parameter `buildId`. It is also found on the build's Parameters tab denoted by the `teamcity.build.id` key. This number is the internal build ID uniquely identifying the build in the TeamCity installation. You might need this ID when composing a URL manually. For example, for [REST API](https://www.jetbrains.com/help/teamcity/rest/teamcity-rest-api-documentation.html) requests or when [downloading build artifacts](patterns-for-accessing-build-artifacts.md).
+The URL of the __Build Results__ page typically looks like the following: `<server_URL>/buildConfiguration/<BuildConfiguration_ID>/<build_ID>?...`. The numeric `build_ID` value is the internal build ID that uniquely identifies this build in TeamCity. This value can be denoted by the `buildId` parameter. You can also find the same value under the build's **Parameters** tab in TeamCity UI, stored in the `teamcity.build.id` parameter.
+
+Knowing a build ID can be required when working with [REST API](https://www.jetbrains.com/help/teamcity/rest/teamcity-rest-api-documentation.html) or [downloading build artifacts](patterns-for-accessing-build-artifacts.md).
 
 ## Build Results Title Panel
 


### PR DESCRIPTION
buildId parameter is only present in the URL if classic UI is used, hence I am adding some clarification