### PR TITLE
Add info about analyzing the server certificate chain

### DIFF
--- a/topics/using-https-to-access-teamcity-server.md
+++ b/topics/using-https-to-access-teamcity-server.md
@@ -120,3 +120,4 @@ For IntelliJ IDEA, you can add the lines into the `bin\idea.exe.vmoptions` file 
 
 * [Online HTTPS server configuration analysis](https://www.ssllabs.com/ssltest/analyze.html)
 * [SSLPoke](https://gist.github.com/4ndrej/4547029) Java class.
+* [openssl-s_client](https://docs.openssl.org/3.0/man1/openssl-s_client/). This example shows the certificate chain: `openssl s_client -connect <server_name>:<port> -showcerts`. It can be useful if you are using a custom trust store and need to ensure all required certificates are included.


### PR DESCRIPTION
Analyzing the certificate chain can be useful when the client JVM doesn't use the default trust store, and the user needs to ensure that the custom trust store includes all the required certificates.