### PR TITLE
Remove the note about non-working file checkout rules

### DIFF
--- a/topics/vcs-checkout-rules.md
+++ b/topics/vcs-checkout-rules.md
@@ -29,12 +29,6 @@ Note that Perforce support in TeamCity treats checkout rules as case-sensitive. 
 </snippet>
 
 
-<note>
-
-Checkout rules can only be set to directories, files are __not__ supported.
-
-</note>
-
 ## Syntax
 
 In the examples below the paths in the repository (`VCSPath`) are relative to the configured VCS root, the paths on the agent (`AgentPath`) are relative to the build checkout directory.


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/TW-90221/Checkout-rules-for-files-are-working-despite-the-note-in-the-checkout-rules-UI

The note about non-working file checkout rules was removed from the UI, but not from the docs