### PR TITLE
Clarify system property names

### DIFF
--- a/topics/artifact-dependencies.md
+++ b/topics/artifact-dependencies.md
@@ -348,12 +348,12 @@ Artifacts repository is protected by a basic authentication. To access the artif
 ```
 
 where `TEAMCITY_HOST` is hostname or IP address of your TeamCity server (without port and servlet context).   
-As `USER_ID/PASSWORD` you can use either username/password of a regular TeamCity user (the user should have corresponding permissions to access artifacts of the source build configuration) or system properties `teamcity.auth.userId/teamcity.auth.password`.
+As `USER_ID`/`PASSWORD` you can use either username/password of a regular TeamCity user (the user should have corresponding permissions to access artifacts of the source build configuration) or system properties `system.teamcity.auth.userId`/`system.teamcity.auth.password`.
 
 ## Build-level authentication
 {id="build-level-auth" help-id="build-level-auth"}
 
-The system properties `teamcity.auth.userId` and `teamcity.auth.password` store automatically generated build-unique values which can be used to authenticate on TeamCity server. The values are valid only during the time the build is running. This generated user has limited permissions which allow build-related operations. The primary intent for the user is to use the authentication to download artifacts from other TeamCity builds within the build script.
+The system properties `system.teamcity.auth.userId` and `system.teamcity.auth.password` store automatically generated build-unique values which can be used to authenticate on TeamCity server. The values are valid only during the time the build is running. This generated user has limited permissions which allow build-related operations. The primary intent for the user is to use the authentication to download artifacts from other TeamCity builds within the build script.
 
 Using the properties is preferable to using real user credentials since it allows the server to track the artifacts downloaded by your build. If the artifacts were downloaded by the build configuration artifact dependencies or using the supplied properties, the specific artifacts used by the build will be displayed at the __Dependencies__ tab on the __Build Results__ page. In addition, the builds which were used to get the artifacts from, can be configured to have different [clean-up](teamcity-data-clean-up.md) logic.
 


### PR DESCRIPTION
Clarify system property names for build-level credentials. System properties are prefixed with `system.`.