### PR TITLE
Remove macOS from the Linux tab title for memory settings

### DIFF
--- a/topics/configure-server-installation.md
+++ b/topics/configure-server-installation.md
@@ -56,7 +56,7 @@ As a JVM application, the TeamCity main server process utilizes only memory avai
 </tab>
 
 
-<tab title="On Linux and macOS">
+<tab title="On Linux">
 
 1. Stop the TeamCity server.
 2. Open the `/etc/environment` file.


### PR DESCRIPTION
The current version of macOS doesn't respect the `/etc/environment` file. There doesn't appear to be a common way for Linux and macOS to set a global, persistent environment variable. It seems the current way of doing it on macOS is via a LaunchAgents configuration file.