### PR TITLE
Remove mTLS documentation

### DIFF
--- a/topics/teamcity-cli-authentication.md
+++ b/topics/teamcity-cli-authentication.md
@@ -310,6 +310,7 @@ teamcity auth login --server https://teamcity-staging.example.com
 There are several ways to target a specific server:
 
 **Environment variable (recommended for scripts):**
+{id="auth-env-vars" help-id="auth-env-vars"}
 
 <tabs>
 <tab title="macOS and Linux">

--- a/topics/teamcity-cli-authentication.md
+++ b/topics/teamcity-cli-authentication.md
@@ -207,7 +207,6 @@ teamcity auth login --insecure-storage
 {style="warning"}
 
 ## Environment variables
-{id="auth-env-vars" help-id="auth-env-vars"}
 
 For CI/CD pipelines and scripted environments, use environment variables instead of interactive login:
 
@@ -276,67 +275,6 @@ Environment variables take precedence over the configuration file and keyring.
 {style="tip"}
 
 > Do not pass tokens as command-line flags in scripts — they may appear in process listings and shell history. Use environment variables instead.
->
-{style="warning"}
-
-## Mutual TLS (mTLS) {id="mtls"}
-
-If your TeamCity server requires client certificate authentication (mutual TLS), configure certificate paths in the config file or via environment variables. mTLS works with all authentication modes (token, basic, guest).
-
-### Per-server configuration
-
-Add `client_cert`, `client_key`, and optionally `ca_cert` to the server entry in `~/.config/tc/config.yml`:
-
-```yaml
-servers:
-    https://teamcity.example.com:
-        user: alice
-        client_cert: /path/to/client.crt
-        client_key: /path/to/client.key
-        ca_cert: /path/to/ca.crt
-```
-
-The `ca_cert` field is only needed when the server uses a certificate signed by a private or internal CA that is not in the system trust store.
-
-### Environment variables
-{id="mtls-env-vars" help-id="mtls-env-vars"}
-
-For CI/CD pipelines, use environment variables instead:
-
-<tabs>
-<tab title="macOS and Linux">
-
-```Shell
-export TEAMCITY_CLIENT_CERT="/path/to/client.crt"
-export TEAMCITY_CLIENT_KEY="/path/to/client.key"
-export TEAMCITY_CA_CERT="/path/to/ca.crt"
-```
-
-</tab>
-<tab title="Windows">
-
-PowerShell:
-
-```PowerShell
-$env:TEAMCITY_CLIENT_CERT = "C:\path\to\client.crt"
-$env:TEAMCITY_CLIENT_KEY = "C:\path\to\client.key"
-$env:TEAMCITY_CA_CERT = "C:\path\to\ca.crt"
-```
-
-CMD:
-
-```Shell
-set TEAMCITY_CLIENT_CERT=C:\path\to\client.crt
-set TEAMCITY_CLIENT_KEY=C:\path\to\client.key
-set TEAMCITY_CA_CERT=C:\path\to\ca.crt
-```
-
-</tab>
-</tabs>
-
-Environment variables take precedence over per-server config file settings.
-
-> Both `TEAMCITY_CLIENT_CERT` and `TEAMCITY_CLIENT_KEY` must be provided together. Specifying only one will result in an error.
 >
 {style="warning"}
 

--- a/topics/teamcity-cli-authentication.md
+++ b/topics/teamcity-cli-authentication.md
@@ -207,6 +207,7 @@ teamcity auth login --insecure-storage
 {style="warning"}
 
 ## Environment variables
+{id="auth-env-vars" help-id="auth-env-vars"}
 
 For CI/CD pipelines and scripted environments, use environment variables instead of interactive login:
 
@@ -310,7 +311,6 @@ teamcity auth login --server https://teamcity-staging.example.com
 There are several ways to target a specific server:
 
 **Environment variable (recommended for scripts):**
-{id="auth-env-vars" help-id="auth-env-vars"}
 
 <tabs>
 <tab title="macOS and Linux">

--- a/topics/teamcity-cli-configuration.md
+++ b/topics/teamcity-cli-configuration.md
@@ -62,7 +62,7 @@ The server URL used when no `TEAMCITY_URL` environment variable is set. Updated 
 </td>
 <td>
 
-A map of server URLs to their settings. Each entry stores the `user` field (username on that server) and optionally `guest: true` for guest access, `ro: true` for read-only mode, or TLS certificate paths for mTLS (`client_cert`, `client_key`, `ca_cert`). Tokens are stored in the system keyring, not in this file, unless `--insecure-storage` was used during login.
+A map of server URLs to their settings. Each entry stores the `user` field (username on that server) and optionally `guest: true` for guest access, `ro: true` for read-only mode. Tokens are stored in the system keyring, not in this file, unless `--insecure-storage` was used during login.
 
 </td>
 </tr>
@@ -154,42 +154,6 @@ Set to `1`, `true`, or `yes` to enable read-only mode. When enabled, all non-GET
 <td>
 
 Path to the Kotlin DSL directory. Overrides automatic detection of `.teamcity/` or `.tc/` directories.
-
-</td>
-</tr>
-<tr>
-<td>
-
-`TEAMCITY_CLIENT_CERT`
-
-</td>
-<td>
-
-Path to a PEM-encoded client certificate file for mutual TLS (mTLS). Must be used together with `TEAMCITY_CLIENT_KEY`. See [Mutual TLS (mTLS)](teamcity-cli-authentication.md#mtls).
-
-</td>
-</tr>
-<tr>
-<td>
-
-`TEAMCITY_CLIENT_KEY`
-
-</td>
-<td>
-
-Path to a PEM-encoded client private key file for mutual TLS (mTLS). Must be used together with `TEAMCITY_CLIENT_CERT`.
-
-</td>
-</tr>
-<tr>
-<td>
-
-`TEAMCITY_CA_CERT`
-
-</td>
-<td>
-
-Path to a PEM-encoded CA certificate file. Use this when the TeamCity server uses a certificate signed by a private or internal CA that is not in the system trust store. Can be used with or without client certificate settings.
 
 </td>
 </tr>


### PR DESCRIPTION
mTLS client certificate support was removed from the CLI in https://github.com/JetBrains/teamcity-cli/pull/179.