### PR TITLE
Fix NuGet cache paths and consolidate formatting

### DIFF
--- a/topics/nuget.md
+++ b/topics/nuget.md
@@ -64,10 +64,10 @@ To install `NuGet.exe` on TeamCity:
 NuGet uses several local caches to avoid downloading packages that are already installed, and to provide offline support. If an agent is running out of the space, TeamCity will try to clean NuGet packages cache on the agent.
 
 The TeamCity NuGet cleaner cleans caches in the following Windows directories:
-* `%NUGET_PACKAGES%` environment variable (must be an absolute path)
-* `%LOCALAPPDATA%\NuGet\Cache`
-* `%LOCALAPPDATA%\NuGet\v3-cache`
-* `%USERPROFILE%\.nuget\packages`
+* `%\NUGET_PACKAGES%` environment variable (must be an absolute path)
+* `%\LOCALAPPDATA%\NuGet\Cache`
+* `%\LOCALAPPDATA%\NuGet\v3-cache`
+* `%\USERPROFILE%\.nuget\packages`
 
 Since TeamCity 2019.2.3, the new automatic package cleaner has been introduced in addition to the existing NuGet cleaner. If .NET SDK is installed on a build agent, TeamCity will use native .NET SDK commands for cleaning. The new cleaner works across all platforms supporting .NET SDK and operates on several levels. It cleans the temporary cache first, and only then gets to cleaning the `.nupkg` files and HTTP requests, if necessary.
 

--- a/topics/nuget.md
+++ b/topics/nuget.md
@@ -64,10 +64,10 @@ To install `NuGet.exe` on TeamCity:
 NuGet uses several local caches to avoid downloading packages that are already installed, and to provide offline support. If an agent is running out of the space, TeamCity will try to clean NuGet packages cache on the agent.
 
 The TeamCity NuGet cleaner cleans caches in the following Windows directories:
-* `%\%NUGET_PACKAGES%% environment variable` (must be an absolute path)
-* `%\%LOCALAPPDATA%%\NuGet\Cache`
-* `%\%LOCALAPPDATA%%\NuGet\v3-cache`
-* `%\%user.home%\.nuget\packages`
+* `%NUGET_PACKAGES%` environment variable (must be an absolute path)
+* `%LOCALAPPDATA%\NuGet\Cache`
+* `%LOCALAPPDATA%\NuGet\v3-cache`
+* `%USERPROFILE%\.nuget\packages`
 
 Since TeamCity 2019.2.3, the new automatic package cleaner has been introduced in addition to the existing NuGet cleaner. If .NET SDK is installed on a build agent, TeamCity will use native .NET SDK commands for cleaning. The new cleaner works across all platforms supporting .NET SDK and operates on several levels. It cleans the temporary cache first, and only then gets to cleaning the `.nupkg` files and HTTP requests, if necessary.
 


### PR DESCRIPTION
When reading https://www.jetbrains.com/help/teamcity/nuget.html#NuGet+Packages+Cache+Clean-up+on+Agents I noticed the inconsistent use of the `%` character:

```
%%NUGET_PACKAGES%% environment variable (must be an absolute path)
%%LOCALAPPDATA%%\NuGet\Cache
%%LOCALAPPDATA%%\NuGet\v3-cache
%%user.home%\.nuget\packages
```

While preparing a pull request, I felt that `user.home` is also not a valid environment variable and could be replaced.

(See also the [NuGet documentation](https://learn.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders) regarding the path details.)