### PR TITLE
TW-100985: Add help-id for Build-scoped Token page

### DIFF
--- a/topics/build-scoped-token.md
+++ b/topics/build-scoped-token.md
@@ -1,3 +1,6 @@
+[//]: # (title: Build-scoped Token)
+[//]: # (help-id: Build Scoped Token)
+
 # Build-scoped Token
 
 The **Build-scoped Token** feature lets builds automatically obtain a short-lived VCS access token. This token is issued through an existing [VCS connection](configuring-connections.md) and stored in a specified parameter. Build steps can then use this token to access and modify resources in the VCS.


### PR DESCRIPTION
Registers the `Build Scoped Token` help-id anchor so that `<bs:help file="Build+Scoped+Token"/>` links in TeamCity UI resolve to this page instead of the documentation home.

Related: https://youtrack.jetbrains.com/issue/TW-100985