### PR TITLE
Update default value for git gc setting

### DIFF
--- a/topics/git.md
+++ b/topics/git.md
@@ -507,7 +507,7 @@ When `fetch` is used in a separate process, it makes thread-dumps of itself and 
 
 <def title="teamcity.server.git.gc.enabled">
 
-<b>Default value:</b> `false`
+<b>Default value:</b> `true`
 
 Specifies whether TeamCity should run `git gc` during the server clean-up (native git is used).
 


### PR DESCRIPTION
Change default value for `teamcity.server.git.gc.enabled` to `true`.