### PR TITLE
TW-101526 [DOC] Configuring Retry Build Triggers﻿: documentation contains invalid property

### DIFF
--- a/topics/configuring-retry-build-trigger.md
+++ b/topics/configuring-retry-build-trigger.md
@@ -3,7 +3,7 @@
 
 The _retry build trigger_ automatically adds a new build to the queue if the previous build of the current build configuration has failed.
 
-Note that if a build fails because of infrastructure issues (for example, a build agent unexpectedly shut down when a build was starting), TeamCity restarts it even without this trigger configured. This behavior is controlled by the `teamcity.buildQueue.restartBuildAttempts` [internal property](server-startup-properties.md#TeamCity+Internal+Properties) that defaults to three consecutive attempts.
+Note that if a build fails because of infrastructure issues (for example, a build agent unexpectedly shut down when a build was starting), TeamCity restarts it even without this trigger configured. This behavior is controlled by the `teamcity.internal.buildQueue.restartBuildAttempts` [internal property](server-startup-properties.md#TeamCity+Internal+Properties) (server-wide default) and can be overridden for individual build configurations using the `teamcity.buildQueue.restartBuildAttempts` configuration parameter. By default, TeamCity makes three consecutive restart attempts.
 {instance="tc"}
 
 Note that if a build fails because of infrastructure issues (for example, a build agent unexpectedly shut down when a build was starting), TeamCity restarts it even without this trigger configured.

--- a/topics/configuring-retry-build-trigger.md
+++ b/topics/configuring-retry-build-trigger.md
@@ -3,7 +3,7 @@
 
 The _retry build trigger_ automatically adds a new build to the queue if the previous build of the current build configuration has failed.
 
-Note that if a build fails because of infrastructure issues (for example, a build agent unexpectedly shut down when a build was starting), TeamCity restarts it even without this trigger configured. This behavior is controlled by the `teamcity.internal.buildQueue.restartBuildAttempts` [internal property](server-startup-properties.md#TeamCity+Internal+Properties) (server-wide default) and can be overridden for individual build configurations using the `teamcity.buildQueue.restartBuildAttempts` configuration parameter. By default, TeamCity makes three consecutive restart attempts.
+Note that if a build fails because of infrastructure issues (for example, a build agent unexpectedly shut down when a build was starting), TeamCity restarts it even without this trigger configured. This behavior is controlled by the `teamcity.internal.buildQueue.restartBuildAttempts` setting, which can be configured globally via an [internal property](server-startup-properties.md#TeamCity+Internal+Properties) or per build configuration. By default, TeamCity makes three consecutive restart attempts.
 {instance="tc"}
 
 Note that if a build fails because of infrastructure issues (for example, a build agent unexpectedly shut down when a build was starting), TeamCity restarts it even without this trigger configured.


### PR DESCRIPTION
This pull request updates the documentation for automatic build restart attempts after infrastructure-related failures. It corrects the property name and clarifies that the setting can be configured either globally or per build configuration.